### PR TITLE
Development -> main

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"gowatch/internal/checker"
 	"gowatch/internal/handler"
 	"gowatch/internal/store"
 	"log"
@@ -20,9 +22,7 @@ func main() {
 		log.Fatalf("failed to initalize store: %v", err)
 	}
 	defer st.Close()
-
-	log.Println("✅ SQLite connected and migrations applied")
-	log.Println("✅ GoWatch server initialized successfully")
+	log.Println("SQLite connected and migrations applied")
 
 	targetHandler := handler.NewTargetHandler(st)
 	http.HandleFunc("POST /api/targets", targetHandler.Create)
@@ -32,8 +32,14 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "GoWatch server is running")
 	})
-	log.Println("Server starting on :8080")
 
+	ctx := context.Background()
+
+	c := checker.New(5, st)
+	c.Start(ctx)
+
+	// サーバー起動処理
+	log.Println("========== Server starting on :8080 ==========")
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -116,17 +116,24 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-c.ticker.C:
+			c.mu.Lock()
 			if c.running {
+				c.mu.Unlock()
 				continue
 			}
 			c.running = true
+			c.mu.Unlock()
 
 			cycleCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
 
 			targets, err := c.store.ListTargets(cycleCtx)
 			if err != nil {
 				cancel()
+
+				c.mu.Lock()
 				c.running = false
+				c.mu.Unlock()
+
 				continue
 			}
 
@@ -135,7 +142,10 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 			}
 
 			cancel()
+
+			c.mu.Lock()
 			c.running = false
+			c.mu.Unlock()
 		}
 	}
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"gowatch/internal/model"
 	"gowatch/internal/store"
+	"log"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -13,17 +15,10 @@ type Checker struct {
 	jobChannel    chan model.Target
 	resultChannel chan model.CheckResult
 	store         *store.Store
-	ctx           context.Context
 	ticker        *time.Ticker
+	mu            sync.Mutex
+	running       bool
 }
-
-// func (c *Checker) runCycle() {
-// 	cycleCtx, cancel := context.WithTimeout(c.ctx, 25*time.Second)
-// 	defer cancel()
-
-// 	urlCtx, cancel := context.WithTimeout(cycleCtx, 5*time.Second)
-// 	defer cancel()
-// }
 
 func New(workNum int, store *store.Store) *Checker {
 	// 1. jobの初期化
@@ -42,18 +37,17 @@ func New(workNum int, store *store.Store) *Checker {
 }
 
 func (c *Checker) Start(ctx context.Context) {
+	c.ticker = time.NewTicker(30 * time.Second)
 	// 1. Workerをgoroutineで起動する（workerNum分）
 	for i := 0; i < c.workNum; i++ {
 		go c.worker(ctx)
 	}
 
 	// 2. Tickerを起動してgoroutineでループする
-	// 別メソッドで記述
 	go c.tickerLoop(ctx)
 
 	// 3. resultChannelを受け取るループをgoroutineで起動する
-	// 別メソッドで記述
-	// go getResultChan()
+	go c.resultLoop(ctx)
 }
 
 func (c *Checker) worker(ctx context.Context) {
@@ -66,8 +60,10 @@ func (c *Checker) worker(ctx context.Context) {
 			// targetを処理する
 			// 確認したいURLを検証する
 			start := time.Now()
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.URL, nil)
+			cycleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			req, err := http.NewRequestWithContext(cycleCtx, http.MethodGet, target.URL, nil)
 			if err != nil {
+				cancel()
 				continue
 			}
 			resp, err := http.DefaultClient.Do(req)
@@ -78,6 +74,7 @@ func (c *Checker) worker(ctx context.Context) {
 					Error:     err.Error(),
 					CheckedAt: time.Now(),
 				}
+				cancel()
 				continue
 			}
 			resp.Body.Close()
@@ -96,6 +93,7 @@ func (c *Checker) worker(ctx context.Context) {
 			}
 
 			// 結果を送る
+			cancel()
 			c.resultChannel <- result
 		}
 	}
@@ -118,13 +116,52 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-c.ticker.C:
-			targets, err := c.store.ListTargets(ctx)
+			if c.running {
+				continue
+			}
+			c.running = true
+
+			cycleCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
+
+			targets, err := c.store.ListTargets(cycleCtx)
 			if err != nil {
+				cancel()
+				c.running = false
 				continue
 			}
 
 			for _, target := range targets {
 				c.jobChannel <- target
+			}
+
+			cancel()
+			c.running = false
+		}
+	}
+}
+
+func (c *Checker) resultLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case result := <-c.resultChannel:
+			// 保存処理
+			if err := c.store.SaveCheckResult(ctx, result); err != nil {
+				log.Printf("saver check result: %v", err)
+				continue
+			}
+
+			// ステータス更新
+			if err := c.store.UpdateTargetStatus(ctx, result.TargetID, result.Status); err != nil {
+				log.Printf("update target status: %v", err)
+				continue
+			}
+
+			// 1,000件超過分削除
+			if err := c.store.DeleteOldCheckResults(ctx, result.TargetID); err != nil {
+				log.Printf("delete old check result: %v", err)
+				continue
 			}
 		}
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1,0 +1,131 @@
+package checker
+
+import (
+	"context"
+	"gowatch/internal/model"
+	"gowatch/internal/store"
+	"net/http"
+	"time"
+)
+
+type Checker struct {
+	workNum       int
+	jobChannel    chan model.Target
+	resultChannel chan model.CheckResult
+	store         *store.Store
+	ctx           context.Context
+	ticker        *time.Ticker
+}
+
+// func (c *Checker) runCycle() {
+// 	cycleCtx, cancel := context.WithTimeout(c.ctx, 25*time.Second)
+// 	defer cancel()
+
+// 	urlCtx, cancel := context.WithTimeout(cycleCtx, 5*time.Second)
+// 	defer cancel()
+// }
+
+func New(workNum int, store *store.Store) *Checker {
+	// 1. jobの初期化
+	job := make(chan model.Target, workNum)
+
+	// 2. 返却値の初期化
+	result := make(chan model.CheckResult, workNum)
+
+	// 3. 構造そのものを初期化
+	return &Checker{
+		workNum:       workNum,
+		jobChannel:    job,
+		resultChannel: result,
+		store:         store,
+	}
+}
+
+func (c *Checker) Start(ctx context.Context) {
+	// 1. Workerをgoroutineで起動する（workerNum分）
+	for i := 0; i < c.workNum; i++ {
+		go c.worker(ctx)
+	}
+
+	// 2. Tickerを起動してgoroutineでループする
+	// 別メソッドで記述
+	go c.tickerLoop(ctx)
+
+	// 3. resultChannelを受け取るループをgoroutineで起動する
+	// 別メソッドで記述
+	// go getResultChan()
+}
+
+func (c *Checker) worker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			// ctxがキャンセルされたら終了
+			return
+		case target := <-c.jobChannel:
+			// targetを処理する
+			// 確認したいURLを検証する
+			start := time.Now()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.URL, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				c.resultChannel <- model.CheckResult{
+					TargetID:  target.ID,
+					Status:    model.StatusDown,
+					Error:     err.Error(),
+					CheckedAt: time.Now(),
+				}
+				continue
+			}
+			resp.Body.Close()
+
+			elapsed := time.Since(start).Milliseconds()
+
+			status := c.judgeStatus(resp.StatusCode, elapsed)
+
+			var result = model.CheckResult{
+				TargetID:       target.ID,
+				Status:         status,
+				StatusCode:     resp.StatusCode,
+				ResponseTimeMs: elapsed,
+				Error:          "",
+				CheckedAt:      time.Now(),
+			}
+
+			// 結果を送る
+			c.resultChannel <- result
+		}
+	}
+}
+
+// ステータスを判定
+func (c *Checker) judgeStatus(statusCode int, elapsed int64) model.Status {
+	if statusCode >= 200 && statusCode < 300 {
+		if elapsed > 2000 {
+			return model.StatusSlow
+		}
+		return model.StatusUp
+	}
+	return model.StatusDown
+}
+
+func (c *Checker) tickerLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.ticker.C:
+			targets, err := c.store.ListTargets(ctx)
+			if err != nil {
+				continue
+			}
+
+			for _, target := range targets {
+				c.jobChannel <- target
+			}
+		}
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -72,7 +72,17 @@ func (s *Store) AddTarget(ctx context.Context, url string, name string) (model.T
 	id := uuid.New().String()
 	now := time.Now()
 
-	_, err := s.db.ExecContext(ctx, "INSERT INTO targets (id, url, name, interval_sec, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)", id, url, name, 30, model.StatusUnknown, now, now)
+	_, err := s.db.ExecContext(
+		ctx,
+		"INSERT INTO targets (id, url, name, interval_sec, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		id,
+		url,
+		name,
+		30,
+		model.StatusUnknown,
+		now,
+		now,
+	)
 	if err != nil {
 		var sqliteErr sqlite3.Error
 		if errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique {
@@ -118,6 +128,56 @@ func (s *Store) DeleteTarget(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, "DELETE FROM targets WHERE id = ?", id)
 	if err != nil {
 		return fmt.Errorf("failed to delete target: %w", err)
+	}
+
+	return nil
+}
+
+// チェック結果を保存
+func (s *Store) SaveCheckResult(ctx context.Context, result model.CheckResult) error {
+	_, err := s.db.ExecContext(
+		ctx,
+		"INSERT INTO check_results (target_id, status, status_code, response_time_ms, error, checked_at) VALUES (?, ?, ?, ?, ?, ?)",
+		result.TargetID,
+		result.Status,
+		result.StatusCode,
+		result.ResponseTimeMs,
+		result.Error,
+		result.CheckedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("save check result: %w", err)
+	}
+
+	return nil
+}
+
+// テーブルのステータスを更新
+func (s *Store) UpdateTargetStatus(ctx context.Context, targetId string, status model.Status) error {
+	_, err := s.db.ExecContext(
+		ctx,
+		"UPDATE check_results SET status = ?, update_at = ? WHERE id = ?",
+		status,
+		time.Now(),
+		targetId,
+	)
+	if err != nil {
+		return fmt.Errorf("update target status: %w", err)
+	}
+
+	return nil
+}
+
+// 直近の1,000件のみ残し古いものを削除
+func (s *Store) DeleteOldCheckResults(ctx context.Context, targetId string) error {
+	_, err := s.db.ExecContext(
+		ctx,
+		"DELETE FROM check_results WHERE target_id = ? AND id NOT IN (SELECT id FROM check_results WHERE target_id = ? ORDER BY checked_at DESC LIMIT 1000)",
+		targetId,
+		targetId,
+	)
+	if err != nil {
+		return fmt.Errorf("delete old check results: %w", err)
 	}
 
 	return nil

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -156,7 +156,7 @@ func (s *Store) SaveCheckResult(ctx context.Context, result model.CheckResult) e
 func (s *Store) UpdateTargetStatus(ctx context.Context, targetId string, status model.Status) error {
 	_, err := s.db.ExecContext(
 		ctx,
-		"UPDATE check_results SET status = ?, update_at = ? WHERE id = ?",
+		"UPDATE targets SET status = ?, updated_at = ? WHERE id = ?",
 		status,
 		time.Now(),
 		targetId,


### PR DESCRIPTION
## 関連 Issue

closes #6 

## 変更内容

- goroutineの実装
- sync.Mutexによるgoroutioneの制御

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 動作確認

- [x] ローカルでビルドが通る (`go build ./cmd/server`)
- [x] 受け入れ条件 (AC) をすべて満たしている
- [x] goroutine リークがないことを確認した（該当する場合）

## メモ

<!-- 実装の判断・迷った点・今後の課題など -->
- goroutineの記述方法（go キーワードの使い方）
- そもそもジョブとは何か？
  - バックグラウンドで稼働させるもの
  - 依頼を受ける → 倉庫に貯める → 処理する → 結果を返す
- channelの型宣言（chan model.Target と model.Target の違い）
- 値とポインタの違い、デリファレンスの概念
  - time.Ticker をポインタで持つ理由
- defer の挙動（無限ループ内では使えない理由）
  - resp.Body.Close() と cancel() を明示的に呼ぶ必要がある
- context階層の設計
  - アプリ全体 → サイクル(25秒) → 個別URL(5秒) の3層
- sync.Mutex の保護範囲
  - Lock範囲は最小限にする（DBアクセスは外に出す）
- http.ListenAndServe がブロックする挙動
  - Checker の起動は必ずその前に書く必要がある
 
<!-- Qiita記事や面接で語れそうなポイントがあればここに残す -->
- Worker Pool パターンの設計判断
  - なぜfan-outではなくWorker Poolか（負荷制御・スケーラビリティ）
- sync.Mutex によるgoroutineの競合制御
  - データ競合とは何か、なぜ起きるか
  - Laravelの withoutOverlapping() と同じ問題をGoで自前実装
- defer が使えないケースの判断
  - 無限ループ内では明示的なClose/cancelが必要
- context階層による処理の制御
  - キャンセルの伝搬とタイムアウトの設計
- http.ListenAndServe のブロッキング挙動を理解した上での起動順序の設計
