### PR TITLE
Issue#4 実装

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,6 +29,7 @@ func main() {
 	http.HandleFunc("POST /api/targets", targetHandler.Create)
 	http.HandleFunc("GET /api/targets", targetHandler.Index)
 	http.HandleFunc("DELETE /api/targets/{id}", targetHandler.Delete)
+	http.HandleFunc("GET /api/targets/{id}/history", targetHandler.History)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "GoWatch server is running")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"gowatch/internal/checker"
 	"gowatch/internal/handler"
 	"gowatch/internal/store"
+	"gowatch/internal/websocket"
 	"log"
 	"net/http"
 	"os"
@@ -35,8 +36,16 @@ func main() {
 
 	ctx := context.Background()
 
-	c := checker.New(5, st)
+	// websocket起動
+	h := websocket.NewHub()
+	go h.Run(ctx)
+
+	// チェッカーの起動
+	c := checker.New(5, st, h)
 	c.Start(ctx)
+
+	wsHandler := handler.NewWSHandler(h)
+	http.HandleFunc("GET /ws", wsHandler.ServeWS)
 
 	// サーバー起動処理
 	log.Println("========== Server starting on :8080 ==========")

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.25.8
 
 require github.com/mattn/go-sqlite3 v1.14.37
 
-require github.com/google/uuid v1.6.0 // indirect
+require (
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/mattn/go-sqlite3 v1.14.37 h1:3DOZp4cXis1cUIpCfXLtmlGolNLp2VEqhiB/PARNBIg=
 github.com/mattn/go-sqlite3 v1.14.37/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -141,9 +141,27 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 				continue
 			}
 
+			cycleStart := model.CycleStart{
+				TargetCount: len(targets),
+				StartedAt:   time.Now(),
+			}
+
+			msg := model.WSMessage{
+				Type:    "cycle_start",
+				Payload: cycleStart,
+			}
+			message, err := json.Marshal(msg)
+			if err != nil {
+				log.Printf("marshal cycle_start: %v", err)
+			} else {
+				c.hub.Broadcast(message)
+			}
+
 			for _, target := range targets {
 				c.jobChannel <- target
 			}
+
+			// todo: 完了メッセージ送信処理追加（Issue6で対応予定）
 
 			cancel()
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2,8 +2,10 @@ package checker
 
 import (
 	"context"
+	"encoding/json"
 	"gowatch/internal/model"
 	"gowatch/internal/store"
+	"gowatch/internal/websocket"
 	"log"
 	"net/http"
 	"sync"
@@ -18,9 +20,10 @@ type Checker struct {
 	ticker        *time.Ticker
 	mu            sync.Mutex
 	running       bool
+	hub           *websocket.Hub
 }
 
-func New(workNum int, store *store.Store) *Checker {
+func New(workNum int, store *store.Store, hub *websocket.Hub) *Checker {
 	// 1. jobの初期化
 	job := make(chan model.Target, workNum)
 
@@ -33,6 +36,7 @@ func New(workNum int, store *store.Store) *Checker {
 		jobChannel:    job,
 		resultChannel: result,
 		store:         store,
+		hub:           hub,
 	}
 }
 
@@ -150,12 +154,21 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 	}
 }
 
+// 返却値を元にDB更新
 func (c *Checker) resultLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case result := <-c.resultChannel:
+			// Hubへ送信
+			message, err := json.Marshal(result)
+			if err != nil {
+				log.Printf("marshal result: %v", err)
+				continue
+			}
+			c.hub.Broadcast(message)
+
 			// 保存処理
 			if err := c.store.SaveCheckResult(ctx, result); err != nil {
 				log.Printf("saver check result: %v", err)

--- a/internal/handler/target.go
+++ b/internal/handler/target.go
@@ -6,6 +6,7 @@ import (
 	"gowatch/internal/store"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 type TargetHandler struct {
@@ -73,6 +74,30 @@ func (h *TargetHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent) // 204
+}
+
+// 履歴取得
+func (h *TargetHandler) History(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	limitStr := r.URL.Query().Get("limit")
+	limit := 100
+
+	// 文字列を数値へ変換
+	if limitStr != "" {
+		if n, err := strconv.Atoi(limitStr); err == nil {
+			limit = n
+		}
+	}
+
+	results, err := h.store.GetCheckResults(r.Context(), id, limit)
+	if err != nil {
+		http.Error(w, "failed to list check_resuls", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(results)
 }
 
 // コンストラクタ

--- a/internal/handler/ws.go
+++ b/internal/handler/ws.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"gowatch/internal/websocket"
+	"net/http"
+)
+
+type WSHandler struct {
+	hub *websocket.Hub
+}
+
+// 初期化
+func NewWSHundler(hub *websocket.Hub) *WSHandler {
+	return &WSHandler{hub: hub}
+}
+
+func (h *WSHandler) ServeWS(w http.ResponseWriter, r *http.Request) {
+	// 1. アップグレード
+
+	// 2. Client作成 + Hub登録
+
+	// 3. writePump goroutine起動
+}

--- a/internal/handler/ws.go
+++ b/internal/handler/ws.go
@@ -3,21 +3,35 @@ package handler
 import (
 	"gowatch/internal/websocket"
 	"net/http"
+
+	ws "github.com/gorilla/websocket"
 )
 
 type WSHandler struct {
 	hub *websocket.Hub
 }
 
+var upgrader = ws.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
 // 初期化
-func NewWSHundler(hub *websocket.Hub) *WSHandler {
+func NewWSHandler(hub *websocket.Hub) *WSHandler {
 	return &WSHandler{hub: hub}
 }
 
+// サーバー起動
 func (h *WSHandler) ServeWS(w http.ResponseWriter, r *http.Request) {
 	// 1. アップグレード
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
 
 	// 2. Client作成 + Hub登録
+	client := websocket.NewClient(h.hub, conn)
+	h.hub.Register(client)
 
 	// 3. writePump goroutine起動
+	go client.WritePump()
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -33,3 +33,22 @@ type CheckResult struct {
 	Error          string    `json:"error,omitempty"`
 	CheckedAt      time.Time `json:"checked_at"`
 }
+
+type WSMessage struct {
+	Type    string `json:"type"`
+	Payload any    `json:"payload"`
+}
+
+type CycleStart struct {
+	TargetCount int       `json:"target_count"`
+	StartedAt   time.Time `json:"started_at"`
+}
+
+type CycleComplete struct {
+	Total       int       `json:"total"`
+	Up          int       `json:"up"`
+	Down        int       `json:"down"`
+	Slow        int       `json:"slow"`
+	DurationMs  int64     `json:"duration_ms"`
+	CompletedAt time.Time `json:"completed_at"`
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -182,3 +182,24 @@ func (s *Store) DeleteOldCheckResults(ctx context.Context, targetId string) erro
 
 	return nil
 }
+
+// 履歴送信API（チェック結果を返信）
+func (s *Store) GetCheckResults(ctx context.Context, targetId string, limit int) ([]model.CheckResult, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT id, target_id, status, status_code, response_time_ms, error, checked_at FROM check_results WHERE target_id = ? ORDER BY checked_at DESC LIMIT ?", targetId, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list check_results: %w", err)
+	}
+	defer rows.Close()
+
+	results := make([]model.CheckResult, 0)
+	for rows.Next() {
+		var r model.CheckResult
+		err := rows.Scan(&r.ID, &r.TargetID, &r.Status, &r.StatusCode, &r.ResponseTimeMs, &r.Error, &r.CheckedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list check_results scan: %w", err)
+		}
+		results = append(results, r)
+	}
+
+	return results, nil
+}

--- a/internal/websocket/client.go
+++ b/internal/websocket/client.go
@@ -9,7 +9,7 @@ type Client struct {
 }
 
 // 初期化
-func ClientNew(hub *Hub, conn *ws.Conn) *Client {
+func NewClient(hub *Hub, conn *ws.Conn) *Client {
 	return &Client{
 		hub:       hub,
 		websocket: conn,
@@ -18,7 +18,7 @@ func ClientNew(hub *Hub, conn *ws.Conn) *Client {
 }
 
 // WebSocketへの書き込み処理
-func (c *Client) writePump() {
+func (c *Client) WritePump() {
 	defer func() {
 		c.hub.unregister <- c
 		c.websocket.Close()

--- a/internal/websocket/client.go
+++ b/internal/websocket/client.go
@@ -1,0 +1,32 @@
+package websocket
+
+import ws "github.com/gorilla/websocket"
+
+type Client struct {
+	hub       *Hub
+	websocket *ws.Conn
+	send      chan []byte
+}
+
+// 初期化
+func ClientNew(hub *Hub, conn *ws.Conn) *Client {
+	return &Client{
+		hub:       hub,
+		websocket: conn,
+		send:      make(chan []byte, 256),
+	}
+}
+
+// WebSocketへの書き込み処理
+func (c *Client) writePump() {
+	defer func() {
+		c.hub.unregister <- c
+		c.websocket.Close()
+	}()
+
+	for message := range c.send {
+		if err := c.websocket.WriteMessage(ws.TextMessage, message); err != nil {
+			return
+		}
+	}
+}

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -45,6 +45,11 @@ func (h *Hub) Run(ctx context.Context) {
 	}
 }
 
+// registerを送る
+func (h *Hub) Register(client *Client) {
+	h.register <- client
+}
+
 // messageを代入
 func (h *Hub) Broadcast(message []byte) {
 	h.broadcast <- message

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -1,0 +1,51 @@
+package websocket
+
+import "context"
+
+type Hub struct {
+	clients    map[*Client]bool
+	register   chan *Client
+	unregister chan *Client
+	broadcast  chan []byte
+}
+
+// 初期化
+func NewHub() *Hub {
+	clients := make(map[*Client]bool)
+
+	register := make(chan *Client)
+
+	unregister := make(chan *Client)
+
+	broadcast := make(chan []byte)
+
+	return &Hub{
+		clients:    clients,
+		register:   register,
+		unregister: unregister,
+		broadcast:  broadcast,
+	}
+}
+
+// メイン
+func (h *Hub) Run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case client := <-h.register: // 新規接続
+			h.clients[client] = true
+		case client := <-h.unregister: // 切断
+			delete(h.clients, client)
+		case message := <-h.broadcast: // 全員に送信
+			for client := range h.clients {
+				client.send <- message
+			}
+		}
+	}
+}
+
+// messageを代入
+func (h *Hub) Broadcast(message []byte) {
+	h.broadcast <- message
+}


### PR DESCRIPTION
## 関連 Issue

closes #6

## 変更内容

- 

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 動作確認

- [x] ローカルでビルドが通る (`go build ./cmd/server`)
- [x] 受け入れ条件 (AC) をすべて満たしている
- [x] goroutine リークがないことを確認した（該当する場合）

## メモ
<!-- 実装の判断・迷った点・今後の課題など -->

- WebSocketの概念理解
  - HTTPとの違い（手紙 vs 電話）
  - upgraderの役割（HTTPからWebSocketへのプロトコル切り替え）
  - GoではHTTPリクエストから始まる仕様のため必ず必要

- パッケージのexport規則
  - 小文字（unexported）は外部パッケージから参照できない
  - register/unregisterはメソッド経由で公開（内部状態を隠蔽）
  - writePump → WritePump に変更

- importの衝突問題
  - gowatch/internal/websocket と gorilla/websocket が同名
  - エイリアス（ws）で解決: `import ws "github.com/gorilla/websocket"`

- for range によるchannelの受け取り
  - `for { select { case v := <-ch } }` は `for v := range ch` に置き換えられる
  - channelが閉じられると自動的にループが終了する

- Hub設計の判断
  - 複数クライアントの管理に map[*Client]bool を使用
  - Broadcastはchannelを通じて非同期に送信

<!-- Qiita・面接で語れるポイント -->

- Hubパターンによるクライアント管理
  - 複数クライアントへの一斉配信の仕組み
  - register/unregister/broadcastをchannelで制御

- WebSocketとHTTPの使い分け
  - REST API: URL の CRUD（追加・削除・一覧・履歴）
  - WebSocket: サーバーからの一方向push（チェック結果・サイクル通知）

- HTTPUpgradeの仕組み
  - ブラウザからの接続は必ずHTTPから始まる
  - upgraderがプロトコルを切り替える

- cycle_completeの実装を保留した判断
  - tickerLoopとresultLoopが別goroutineのため集計が複雑
  - フロントエンド実装直前に改めて設計する
