### PR TITLE
Development

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,7 +58,10 @@ func main() {
 
 	// サーバー起動処理
 	log.Println("========== Server starting on :8080 ==========")
-	srv := &http.Server{Addr: ":8080"}
+	srv := &http.Server{
+    Addr:    ":8080",
+    Handler: corsMiddleware(http.DefaultServeMux),
+	}
 	go srv.ListenAndServe()
 
 	<-ctx.Done()
@@ -66,4 +69,21 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	srv.Shutdown(shutdownCtx)
+}
+
+// CORSミドルウェア
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "http://localhost:5173")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		// プリフライトリクエストへの対応
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,7 +86,11 @@ function App() {
     }
   }, []);
 
-  useWebSocket(handleMessage);
+  useWebSocket({
+    onMessage: handleMessage,
+    onConnect: () => dispatch({ type: 'SET_CONNECTED', payload: true }),
+    onDisconnect: () => dispatch({ type: 'SET_CONNECTED', payload: false }),
+  });
 
   const targets = Array.from(state.targets.values());
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,121 +1,113 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import './App.css'
+import { useReducer, useEffect, useCallback, useState } from 'react';
+import type { Target, CheckResult, WSMessage, CycleComplete } from './types';
+import { api } from './api/client';
+import { useWebSocket } from './hooks/useWebSocket';
+import { Header } from './components/Header';
+import { SummaryCards } from './components/SummaryCards';
+import { TargetTable } from './components/TargetTable';
+import { AddTargetModal } from './components/AddTargetModal';
 
-function App() {
-  const [count, setCount] = useState(0)
+type State = {
+  targets: Map<string, Target>;
+  connected: boolean;
+  lastCycle: CycleComplete | null;
+  selectedTargetId: string | null;
+};
 
-  return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
-      </section>
+const initialState: State = {
+  targets: new Map(),
+  connected: false,
+  lastCycle: null,
+  selectedTargetId: null,
+};
 
-      <div className="ticks"></div>
+type Action =
+  | { type: 'SET_TARGETS'; payload: Target[] }
+  | { type: 'UPDATE_TARGET'; payload: CheckResult }
+  | { type: 'ADD_TARGET'; payload: Target }
+  | { type: 'DELETE_TARGET'; payload: string }
+  | { type: 'SET_CONNECTED'; payload: boolean }
+  | { type: 'SET_LAST_CYCLE'; payload: CycleComplete }
+  | { type: 'SELECT_TARGET'; payload: string | null };
 
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
-  )
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SET_TARGETS': {
+      const map = new Map(action.payload.map((t) => [t.id, t]));
+      return { ...state, targets: map };
+    }
+    case 'UPDATE_TARGET': {
+      const result = action.payload;
+      const target = state.targets.get(result.target_id);
+      if (!target) return state;
+      const updated = new Map(state.targets);
+      updated.set(result.target_id, { ...target, status: result.status });
+      return { ...state, targets: updated };
+    }
+    case 'ADD_TARGET': {
+      const updated = new Map(state.targets);
+      updated.set(action.payload.id, action.payload);
+      return { ...state, targets: updated };
+    }
+    case 'DELETE_TARGET': {
+      const updated = new Map(state.targets);
+      updated.delete(action.payload);
+      return { ...state, targets: updated };
+    }
+    case 'SET_CONNECTED':
+      return { ...state, connected: action.payload };
+    case 'SET_LAST_CYCLE':
+      return { ...state, lastCycle: action.payload };
+    case 'SELECT_TARGET':
+      return { ...state, selectedTargetId: action.payload };
+    default:
+      return state;
+  }
 }
 
-export default App
+function App() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    api.getTargets().then((targets) => {
+      dispatch({ type: 'SET_TARGETS', payload: targets });
+    });
+  }, []);
+
+  const handleMessage = useCallback((msg: WSMessage) => {
+    switch (msg.type) {
+      case 'check_result':
+        dispatch({ type: 'UPDATE_TARGET', payload: msg.payload });
+        break;
+      case 'cycle_complete':
+        dispatch({ type: 'SET_LAST_CYCLE', payload: msg.payload });
+        break;
+    }
+  }, []);
+
+  useWebSocket(handleMessage);
+
+  const targets = Array.from(state.targets.values());
+
+  return (
+    <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
+      <Header connected={state.connected} onAddClick={() => setShowModal(true)} />
+      <SummaryCards targets={targets} lastCycle={state.lastCycle} />
+      <div style={{ padding: '16px' }}>
+        <TargetTable
+          targets={targets}
+          onDelete={(id) => dispatch({ type: 'DELETE_TARGET', payload: id })}
+        />
+      </div>
+      {showModal && (
+        <AddTargetModal
+          onAdd={(target) => dispatch({ type: 'ADD_TARGET', payload: target })}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,38 @@
+import type { Target } from '../types';
+
+const BASE_URL = 'http://localhost:8080';
+
+export const api = {
+  // URL一覧取得
+  getTargets: async (): Promise<Target[]> => {
+    const res = await fetch(`${BASE_URL}/api/targets`);
+    if (!res.ok) throw new Error('Failed to fetch targets');
+    return res.json();
+  },
+
+  // URL登録
+  addTarget: async (url: string, name: string): Promise<Target> => {
+    const res = await fetch(`${BASE_URL}/api/targets`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, name }),
+    });
+    if (!res.ok) throw new Error('Failed to add target');
+    return res.json();
+  },
+
+  // URL削除
+  deleteTarget: async (id: string): Promise<void> => {
+    const res = await fetch(`${BASE_URL}/api/targets/${id}`, {
+      method: 'DELETE',
+    });
+    if (!res.ok) throw new Error('Failed to delete target');
+  },
+
+  // 履歴取得
+  getHistory: async (id: string, limit = 100) => {
+    const res = await fetch(`${BASE_URL}/api/targets/${id}/history?limit=${limit}`);
+    if (!res.ok) throw new Error('Failed to fetch history');
+    return res.json();
+  },
+};

--- a/frontend/src/components/AddTargetModal.tsx
+++ b/frontend/src/components/AddTargetModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { api } from '../api/client';
+import type { Target } from '../types';
+
+type Props = {
+  onAdd: (target: Target) => void;
+  onClose: () => void;
+};
+
+export function AddTargetModal({ onAdd, onClose }: Props) {
+  const [url, setUrl] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    if (!url || !name) {
+      setError('URLと名前を入力してください');
+      return;
+    }
+    try {
+      const target = await api.addTarget(url, name);
+      onAdd(target);
+      onClose();
+    } catch (e) {
+      setError('登録に失敗しました');
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div style={{ background: '#fff', padding: '24px', borderRadius: '8px', width: '400px' }}>
+        <h2>Add URL</h2>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <div style={{ marginBottom: '12px' }}>
+          <label>URL</label>
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://example.com"
+            style={{ display: 'block', width: '100%', padding: '8px', marginTop: '4px' }}
+          />
+        </div>
+        <div style={{ marginBottom: '12px' }}>
+          <label>名前</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Site"
+            style={{ display: 'block', width: '100%', padding: '8px', marginTop: '4px' }}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button onClick={onClose}>キャンセル</button>
+          <button onClick={handleSubmit}>追加</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  connected: boolean;
+  onAddClick: () => void;
+};
+
+export function Header({ connected, onAddClick }: Props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '16px',
+        borderBottom: '1px solid #ccc',
+      }}
+    >
+      <h1 style={{ margin: 0 }}>GoWatch</h1>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+        <span>{connected ? '🟢 Connected' : '🔴 Disconnected'}</span>
+        <button onClick={onAddClick}>+ Add URL</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SummaryCards.tsx
+++ b/frontend/src/components/SummaryCards.tsx
@@ -1,0 +1,51 @@
+import type { Target, CycleComplete } from '../types';
+
+type Props = {
+  targets: Target[];
+  lastCycle: CycleComplete | null;
+};
+
+export function SummaryCards({ targets, lastCycle }: Props) {
+  const up = targets.filter((t) => t.status === 'up').length;
+  const down = targets.filter((t) => t.status === 'down').length;
+  const slow = targets.filter((t) => t.status === 'slow').length;
+
+  return (
+    <div style={{ display: 'flex', gap: '16px', padding: '16px' }}>
+      <div
+        style={{
+          padding: '16px',
+          border: '1px solid green',
+          borderRadius: '8px',
+          minWidth: '100px',
+        }}
+      >
+        <div style={{ color: 'green', fontSize: '24px' }}>{up}</div>
+        <div>UP</div>
+      </div>
+      <div
+        style={{ padding: '16px', border: '1px solid red', borderRadius: '8px', minWidth: '100px' }}
+      >
+        <div style={{ color: 'red', fontSize: '24px' }}>{down}</div>
+        <div>DOWN</div>
+      </div>
+      <div
+        style={{
+          padding: '16px',
+          border: '1px solid orange',
+          borderRadius: '8px',
+          minWidth: '100px',
+        }}
+      >
+        <div style={{ color: 'orange', fontSize: '24px' }}>{slow}</div>
+        <div>SLOW</div>
+      </div>
+      {lastCycle && (
+        <div style={{ padding: '16px', border: '1px solid #ccc', borderRadius: '8px' }}>
+          <div style={{ fontSize: '12px', color: '#666' }}>最終サイクル</div>
+          <div>{new Date(lastCycle.completed_at).toLocaleTimeString()}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TargetRow.tsx
+++ b/frontend/src/components/TargetRow.tsx
@@ -1,0 +1,36 @@
+import { api } from '../api/client';
+import type { Target } from '../types';
+
+type Props = {
+  target: Target;
+  onDelete: (id: string) => void;
+};
+
+const statusColor: Record<string, string> = {
+  up: 'green',
+  down: 'red',
+  slow: 'orange',
+  unknown: 'gray',
+};
+
+export function TargetRow({ target, onDelete }: Props) {
+  const handleDelete = async () => {
+    try {
+      await api.deleteTarget(target.id);
+      onDelete(target.id);
+    } catch (e) {
+      console.error('Failed to delete target', e);
+    }
+  };
+
+  return (
+    <tr>
+      <td>{target.name}</td>
+      <td>{target.url}</td>
+      <td style={{ color: statusColor[target.status] }}>{target.status.toUpperCase()}</td>
+      <td>
+        <button onClick={handleDelete}>削除</button>
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/components/TargetTable.tsx
+++ b/frontend/src/components/TargetTable.tsx
@@ -1,0 +1,31 @@
+import type { Target } from '../types';
+import { TargetRow } from './TargetRow';
+
+type Props = {
+  targets: Target[];
+  onDelete: (id: string) => void;
+};
+
+export function TargetTable({ targets, onDelete }: Props) {
+  if (targets.length === 0) {
+    return <p>監視対象がありません。URLを追加してください。</p>;
+  }
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr style={{ borderBottom: '1px solid #ccc' }}>
+          <th style={{ textAlign: 'left', padding: '8px' }}>名前</th>
+          <th style={{ textAlign: 'left', padding: '8px' }}>URL</th>
+          <th style={{ textAlign: 'left', padding: '8px' }}>ステータス</th>
+          <th style={{ textAlign: 'left', padding: '8px' }}>操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {targets.map((target) => (
+          <TargetRow key={target.id} target={target} onDelete={onDelete} />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useCallback } from 'react';
+import type { WSMessage } from '../types';
+
+const WS_URL = 'ws://localhost:8080/ws';
+
+export const useWebSocket = (onMessage: (msg: WSMessage) => void) => {
+  const wsRef = useRef<WebSocket | null>(null);
+  const onMessageRef = useRef(onMessage);
+
+  // onMessageが変わっても最新を参照する
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+  }, [onMessage]);
+
+  const connect = useCallback(() => {
+    const ws = new WebSocket(WS_URL);
+
+    ws.onopen = () => {
+      console.log('WebSocket connected');
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg: WSMessage = JSON.parse(event.data);
+        onMessageRef.current(msg);
+      } catch (e) {
+        console.error('Failed to parse message', e);
+      }
+    };
+
+    ws.onclose = () => {
+      console.log('WebSocket disconnected, reconnecting...');
+      // 3秒後に再接続
+      setTimeout(connect, 3000);
+    };
+
+    ws.onerror = (e) => {
+      console.error('WebSocket error', e);
+    };
+
+    wsRef.current = ws;
+  }, []);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      wsRef.current?.close();
+    };
+  }, [connect]);
+};

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -3,7 +3,13 @@ import type { WSMessage } from '../types';
 
 const WS_URL = 'ws://localhost:8080/ws';
 
-export const useWebSocket = (onMessage: (msg: WSMessage) => void) => {
+type Props = {
+  onMessage: (msg: WSMessage) => void;
+  onConnect: () => void;
+  onDisconnect: () => void;
+};
+
+export const useWebSocket = ({ onMessage, onConnect, onDisconnect }: Props) => {
   const wsRef = useRef<WebSocket | null>(null);
   const onMessageRef = useRef(onMessage);
 
@@ -17,6 +23,7 @@ export const useWebSocket = (onMessage: (msg: WSMessage) => void) => {
 
     ws.onopen = () => {
       console.log('WebSocket connected');
+      onConnect();
     };
 
     ws.onmessage = (event) => {
@@ -30,6 +37,7 @@ export const useWebSocket = (onMessage: (msg: WSMessage) => void) => {
 
     ws.onclose = () => {
       console.log('WebSocket disconnected, reconnecting...');
+      onDisconnect();
       // 3秒後に再接続
       setTimeout(connect, 3000);
     };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,41 @@
+export type Status = 'up' | 'down' | 'slow' | 'unknown';
+
+export type Target = {
+  id: string;
+  url: string;
+  name: string;
+  interval_sec: number;
+  status: Status;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CheckResult = {
+  id: number;
+  target_id: string;
+  status: Status;
+  status_code: number;
+  response_time_ms: number;
+  error?: string;
+  checked_at: string;
+};
+
+export type WSMessage =
+  | { type: 'check_result'; payload: CheckResult }
+  | { type: 'cycle_start'; payload: CycleStart }
+  | { type: 'cycle_complete'; payload: CycleComplete }
+  | { type: 'targets_updated'; payload: Target[] };
+
+export type CycleStart = {
+  target_count: number;
+  started_at: string;
+};
+
+export type CycleComplete = {
+  total: number;
+  up: number;
+  down: number;
+  slow: number;
+  duration_ms: number;
+  completed_at: string;
+};

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -21,6 +21,12 @@ type Checker struct {
 	mu            sync.Mutex
 	running       bool
 	hub           *websocket.Hub
+	cycleStart    time.Time
+	cycleUp       int
+	cycleDown     int
+	cycleSlow     int
+	cycleExpected int
+	cycleDone     int
 }
 
 func New(workNum int, store *store.Store, hub *websocket.Hub) *Checker {
@@ -141,9 +147,11 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 				continue
 			}
 
+			now := time.Now()
+
 			cycleStart := model.CycleStart{
 				TargetCount: len(targets),
-				StartedAt:   time.Now(),
+				StartedAt:   now,
 			}
 
 			msg := model.WSMessage{
@@ -161,12 +169,16 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 				c.jobChannel <- target
 			}
 
-			// todo: 完了メッセージ送信処理追加（Issue6で対応予定）
-
 			cancel()
 
 			c.mu.Lock()
 			c.running = false
+			c.cycleStart = now
+			c.cycleExpected = len(targets)
+			c.cycleDone = 0
+			c.cycleUp = 0
+			c.cycleDown = 0
+			c.cycleSlow = 0
 			c.mu.Unlock()
 		}
 	}
@@ -203,6 +215,48 @@ func (c *Checker) resultLoop(ctx context.Context) {
 			if err := c.store.DeleteOldCheckResults(ctx, result.TargetID); err != nil {
 				log.Printf("delete old check result: %v", err)
 				continue
+			}
+
+			// サイクル集計
+			c.mu.Lock()
+			switch result.Status {
+			case model.StatusUp:
+				c.cycleUp++
+			case model.StatusDown:
+				c.cycleDown++
+			case model.StatusSlow:
+				c.cycleSlow++
+			}
+			c.cycleDone++
+			done := c.cycleDone
+			expected := c.cycleExpected
+			cycleStart := c.cycleStart
+			up := c.cycleUp
+			down := c.cycleDown
+			slow := c.cycleSlow
+			c.mu.Unlock()
+
+			// 全件揃ったらcycle_completeを送る
+			if expected > 0 && done >= expected {
+				cycleComplete := model.CycleComplete{
+					Total:       expected,
+					Up:          up,
+					Down:        down,
+					Slow:        slow,
+					DurationMs:  time.Since(cycleStart).Milliseconds(),
+					CompletedAt: time.Now(),
+				}
+				msg := model.WSMessage{
+					Type:    "cycle_complete",
+					Payload: cycleComplete,
+				}
+				message, err := json.Marshal(msg)
+				if err != nil {
+					log.Printf("marshal cycle_complete: %v", err)
+					continue
+				} else {
+					c.hub.Broadcast(message)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## 関連 Issue

closes #9 

## 変更内容

- フロントエンドの実装
- バックエンドからサイクルタイムの送信

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 動作確認

- [x] ローカルでビルドが通る (`go build ./cmd/server`)
- [x] 受け入れ条件 (AC) をすべて満たしている
- [x] goroutine リークがないことを確認した（該当する場合）

## メモ

## Issue #6: React フロントエンド実装

<!-- 実装の判断・迷った点・今後の課題など -->

- CORSエラーへの対応
  - GoバックエンドがReactからのリクエストを拒否する
  - corsMiddlewareを追加してAccess-Control-Allow-Originを設定
  - プリフライトリクエスト（OPTIONS）への対応も必要

- useWebSocketのコールバック設計
  - onConnect / onDisconnect をコールバックとして受け取る
  - 接続状態をAppのStateに反映させる
  - onMessageRefでコールバックの最新参照を保持する

- useReducerによるState管理
  - targetsをMapで管理（id → Target）
  - WebSocketメッセージを受け取るたびにdispatchで更新
  - ReduxやZustandは不要なスコープ

- cycle_completeの実装
  - tickerLoopとresultLoopが別goroutineのため集計が複雑
  - CheckerにcycleExpected / cycleDoneフィールドを追加
  - 全件揃ったタイミングでcycle_completeをBroadcast

- Hub送信の順番
  - check_resultはDB保存より前にBroadcast（UI反映優先）
  - cycle_completeは全件保存後にBroadcast

<!-- Qiita・面接で語れるポイント -->

- CORSの仕組み
  - ブラウザが異なるオリジン間のリクエストを制限する
  - サーバー側でヘッダーを返すことで許可する

- useReducerパターン
  - 複数のコンポーネントにまたがるStateをまとめて管理
  - ActionとReducerで状態遷移を明示的に表現

- WebSocketメッセージのtype判別
  - typeフィールドでcheck_result/cycle_start/cycle_completeを振り分け
  - 新しいメッセージタイプを追加しても既存コードへの影響が少ない

- cycle_complete集計の設計判断
  - cycleExpectedとcycleDoneで全件完了を検知
  - sync.Mutexで複数goroutineからの安全なアクセスを保証
