### PR TITLE
Development

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gowatch/internal/checker"
 	"gowatch/internal/handler"
+	"gowatch/internal/notifier"
 	"gowatch/internal/store"
 	"gowatch/internal/websocket"
 	"log"
@@ -45,12 +46,20 @@ func main() {
 	)
 	defer stop()
 
+	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
+	var n checker.Notifier
+	if webhookURL == "" {
+		n = &notifier.NopNotifier{}
+	} else {
+		n = notifier.NewSlackNotifier(webhookURL)
+	}
+
 	// websocket起動
 	h := websocket.NewHub()
 	go h.Run(ctx)
 
 	// チェッカーの起動
-	c := checker.New(5, st, h)
+	c := checker.New(5, st, h, n)
 	c.Start(ctx)
 
 	wsHandler := handler.NewWSHandler(h)
@@ -59,8 +68,8 @@ func main() {
 	// サーバー起動処理
 	log.Println("========== Server starting on :8080 ==========")
 	srv := &http.Server{
-    Addr:    ":8080",
-    Handler: corsMiddleware(http.DefaultServeMux),
+		Addr:    ":8080",
+		Handler: corsMiddleware(http.DefaultServeMux),
 	}
 	go srv.ListenAndServe()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     environment:
       - DB_PATH=/data/gowatch.db
       - GO_ENV=development
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+    env_file:
+      - .env
     depends_on: []
     tty: true
 

--- a/docs/github_issues.md
+++ b/docs/github_issues.md
@@ -272,3 +272,45 @@ WebSocket 接続・URL 追加モーダル・ステータス一覧テーブル・
 - [ ] README に動機・アーキテクチャ・セットアップ手順・技術ハイライトが記載されている
 - [ ] README のセットアップ手順に従って第三者が起動できる
 - [ ] デモ動画 (or GIF) が README に埋め込まれている
+
+---
+
+## Issue #9: Slack 通知機能の追加
+
+**Labels:** `backend` `feature`
+
+### 説明
+
+DOWN 検知時に Slack へ通知を送る機能を追加する。
+通知先を将来 Discord 等に切り替え・追加できる設計にするため、
+`internal/checker` に `Notifier` interface を定義し、`internal/notifier` に実装を置く。
+通知失敗時はシステムを止めず、Toast でユーザーへフィードバックする。
+
+### やること
+
+- `internal/checker/checker.go` に `Notifier` interface を追加
+  - `type Notifier interface { Notify(message string) error }`
+  - DOWN 検知時に `Notifier.Notify()` を呼び出す
+  - 通知失敗時はログ出力 + Hub 経由で `notification_error` メッセージを送信
+- `internal/notifier/slack.go` — SlackNotifier 実装
+  - Incoming Webhook を使った通知送信
+  - `Notify(message string) error` メソッドを実装
+- `internal/websocket/hub.go` に `notification_error` メッセージタイプを追加
+- `cmd/server/main.go` で SlackNotifier を Checker に注入
+  - `SLACK_WEBHOOK_URL` 環境変数から Webhook URL を取得
+  - URL 未設定の場合は通知なしで起動
+- `docker-compose.yml` に `SLACK_WEBHOOK_URL` 環境変数を追加
+
+### 受け入れ条件 (AC)
+
+- [ ] DOWN 検知時に Slack へ通知が届く
+- [ ] Slack 通知が失敗してもヘルスチェックが継続される
+- [ ] 通知失敗時に Toast が表示される
+- [ ] `SLACK_WEBHOOK_URL` 未設定でもサーバーが正常起動する
+- [ ] `checker` パッケージが `notifier` パッケージを import していない
+- [ ] `go build ./cmd/server` がエラーなく通る
+
+### 関連
+
+- 設計ドキュメント §4 (Out of Scope → 拡張候補)
+- 将来の拡張: `internal/notifier/discord.go` を追加するだけで Discord 通知に対応できる

--- a/docs/qiita/01_goroutine_channel.md
+++ b/docs/qiita/01_goroutine_channel.md
@@ -1,0 +1,139 @@
+# GoWatchを作りながら学ぶGoの並行処理 #1 — goroutineとchannelの基本
+
+## はじめに
+
+この記事は、URLヘルスモニタリングツール **GoWatch** を実装しながらGoの並行処理を学んだ記録です。
+
+このシリーズを読み終えると、以下のようなツールを自分で実装できるようになります。
+
+- 複数のURLを並列でヘルスチェックする
+- チェック結果をリアルタイムでブラウザに通知する
+- サーバーを安全に停止する（Graceful Shutdown）
+
+GoWatchのソースコードはこちら → [GitHub](https://github.com/north238/go-watch)
+
+---
+
+GoWatchを作ったきっかけは2つあります。1つ目は以前ポートフォリオとして自作したWebアプリを自分で監視したかったこと、2つ目はGoを使った実践的な開発を通じて並行処理を深く学びたかったことです。
+
+複数のURLを**同時に**チェックする必要があるため、並行処理が不可欠なプロジェクトです。GoWatchはそのユースケースとGoの並行処理を学ぶ題材として非常に相性がよいと感じています。
+
+このシリーズでは以下を学びます。
+
+- goroutineとchannel（本記事）
+- Worker Poolパターンで並列数を制御する
+- contextでキャンセルを伝播させる
+- 実装してわかったハマりどころ
+
+対象読者はGoの基本文法は知っているが並行処理はまだ自信がない方です。
+
+---
+
+## goroutineとは
+
+goroutineはGoが提供する**軽量な並行実行の単位**です。
+
+OSのスレッドと比べると非常に軽量で、数千〜数万のgoroutineを同時に起動しても問題ありません。起動方法はシンプルで、関数呼び出しの前に `go` をつけるだけです。
+
+```go
+func main() {
+    go hello() // goroutineとして起動
+    hello()    // 通常の呼び出し
+}
+
+func hello() {
+    fmt.Println("hello")
+}
+```
+
+ただしこのコードには問題があります。`main` 関数が終了するとすべてのgoroutineも強制終了するため、`go hello()` が実行される前にプログラムが終わってしまうことがあります。
+
+goroutineの終了を待つ方法はいくつかありますが、その一つが次に紹介するchannelです。
+
+---
+
+## channelとは
+
+channelはgoroutine間で**値を安全にやり取りするための通路**です。
+
+Goには「メモリを共有して通信するのではなく、通信によってメモリを共有する」という設計思想があります。channelはその思想を体現した仕組みです。
+
+### 基本的な使い方
+
+```go
+func main() {
+    ch := make(chan string) // stringを渡すchannelを作成
+
+    go func() {
+        ch <- "hello" // channelに送信
+    }()
+
+    msg := <-ch // channelから受信（goroutineが送信するまでここで待つ）
+    fmt.Println(msg) // "hello"
+}
+```
+
+ポイントは受信側（`<-ch`）がブロッキングする点です。goroutineが値を送信するまでメイン処理はここで待機します。これによって先ほどの「mainが先に終わってしまう」問題を解決できます。
+
+### buffered channel
+
+`make(chan string)` はバッファなしのchannelです。送信側は受信側が受け取るまでブロックされます。
+
+バッファを持たせると、受信側が準備できていなくても指定した数まで送信できます。
+
+```go
+ch := make(chan string, 3) // バッファサイズ3のchannel
+
+ch <- "a" // 受信側がいなくてもブロックされない
+ch <- "b"
+ch <- "c"
+// ch <- "d" // バッファが埋まるのでここでブロック
+```
+
+---
+
+## GoWatchではどう使っているか
+
+GoWatchのチェック処理を担う `checker` パッケージでは、goroutineとchannelを次のような形で使っています。
+
+```
+[tickerLoop goroutine]
+    │ 一定間隔でチェック対象URLを送信
+    ▼
+  jobs channel
+    │
+    ▼
+[worker goroutine × N]
+    │ URLにHTTPリクエストを送信
+    ▼
+  results channel
+    │
+    ▼
+[resultLoop goroutine]
+    │ 結果をDBに保存 & WebSocketで通知
+```
+
+複数のURLを並列でチェックするために `worker` goroutineを複数起動し、`jobs` channelを通じて仕事を渡しています。これをWorker Poolパターンと呼びます。
+
+詳細は次回の記事で解説します。
+
+---
+
+## まとめ
+
+この記事で学んだことは3つです。
+
+- goroutineは `go` キーワードで起動できる軽量な並行実行の単位
+- channelはgoroutine間で値を安全に渡すための仕組みで、受信側はブロッキングする
+- GoWatchでは複数URLを並列チェックするためにgoroutineとchannelを組み合わせている
+
+**次回** はWorker Poolパターンを取り上げます。goroutineを無制限に起動することの問題点と、GoWatchでどう制御しているかを実装コードを交えて解説します。
+
+---
+
+## 参考
+
+- [A Tour of Go](https://go.dev/tour/)
+- [Go by Example - Goroutines](https://gobyexample.com/goroutines)
+- [Go by Example - Channels](https://gobyexample.com/channels)
+- [pkg.go.dev/context](https://pkg.go.dev/context)

--- a/docs/qiita/02_worker_pool.md
+++ b/docs/qiita/02_worker_pool.md
@@ -1,0 +1,169 @@
+# GoWatchを作りながら学ぶGoの並行処理 #2 — Worker Poolパターンでgoroutineを制御する
+
+## はじめに
+
+前回はgoroutineとchannelの基本を学びました。
+
+- goroutineは `go` キーワードで起動できる軽量な並行実行の単位
+- channelはgoroutine間で値を安全に渡すための通路
+
+今回はその知識を活かして、GoWatchの中核となる **Worker Poolパターン** を解説します。
+
+---
+
+## goroutineを無制限に起動する問題
+
+前回学んだようにgoroutineは非常に軽量です。では、監視対象のURLが増えるたびにgoroutineを1つずつ起動すればよいのでしょうか。
+
+```go
+// ❌ URLごとにgoroutineを起動する素朴な実装
+for _, url := range urls {
+    go check(url)
+}
+```
+
+少数のURLであれば問題ありません。しかし監視対象が100件、1000件と増えたとき、同じ数だけgoroutineが同時に起動します。goroutineは軽量とはいえ無制限に起動すれば以下の問題が起きます。
+
+- メモリを大量に消費する
+- 外部サービスへのリクエストが集中してサーバーに負荷をかける
+- リソースの枯渇によりシステム全体が不安定になる
+
+並行処理の数を**意図的に制御する**仕組みが必要です。
+
+---
+
+## Worker Poolパターンとは
+
+Worker Poolパターンは、あらかじめ決まった数のworker（goroutine）を起動しておき、jobsをchannelで渡すことで並列数を制御するパターンです。
+
+```
+[送信側]
+    │ jobsをchannelに送信
+    ▼
+  jobs channel
+    │
+    ├─ [worker 1]
+    ├─ [worker 2]  ← 常にN個のworkerだけが動いている
+    └─ [worker 3]
+    │
+    ▼
+  results channel
+    │
+    ▼
+[受信側]
+    │ 結果を処理
+```
+
+workerの数を固定することで「同時に処理できるjobの上限」を制御できます。jobsがworkerの数より多くても、channelがバッファとして機能するため処理が詰まることなく順番にさばいていきます。
+
+---
+
+## GoWatchでの実装
+
+### Checkerの構造体
+
+GoWatchでは `Checker` 構造体がWorker Poolを管理しています。
+
+```go
+type Checker struct {
+    db          *store.Store
+    hub         *websocket.Hub
+    jobs        chan string
+    results     chan CheckResult
+    workerCount int
+}
+
+func New(db *store.Store, hub *websocket.Hub, workerCount int) *Checker {
+    return &Checker{
+        db:          db,
+        hub:         hub,
+        jobs:        make(chan string, workerCount),
+        results:     make(chan CheckResult, workerCount),
+        workerCount: workerCount,
+    }
+}
+```
+
+`jobs` と `results` はどちらも `workerCount` をバッファサイズとしています。workerが処理できる数だけ先行して受け付けられるようにするためです。
+
+### Start() — workerを起動する
+
+```go
+func (c *Checker) Start(ctx context.Context) {
+    for i := 0; i < c.workerCount; i++ {
+        go c.worker(ctx)
+    }
+
+    go c.resultLoop(ctx)
+    go c.tickerLoop(ctx)
+}
+```
+
+`Start()` が呼ばれると `workerCount` の数だけ `worker` goroutineを起動します。以降、workerの数は増えも減りもしません。
+
+### worker() — jobsを受け取って処理する
+
+```go
+func (c *Checker) worker(ctx context.Context) {
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case url, ok := <-c.jobs:
+            if !ok {
+                return
+            }
+            result := c.check(ctx, url)
+            c.results <- result
+        }
+    }
+}
+```
+
+各workerは `jobs` channelを監視し続け、URLが送られてきたらHTTPリクエストを送信して結果を `results` channelに流します。`ctx.Done()` を監視しているのはアプリケーション終了時に安全にworkerを止めるためです。これはシリーズ#3で詳しく解説します。
+
+### tickerLoop() — 定期的にjobsを送信する
+
+```go
+func (c *Checker) tickerLoop(ctx context.Context) {
+    ticker := time.NewTicker(30 * time.Second)
+    defer ticker.Stop()
+
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            targets, err := c.db.ListTargets(ctx)
+            if err != nil {
+                continue
+            }
+            for _, t := range targets {
+                c.jobs <- t.URL
+            }
+        }
+    }
+}
+```
+
+30秒ごとにDBから監視対象URLを取得し、1件ずつ `jobs` channelに送信します。workerは受け取った順に処理するため、一度に大量のHTTPリクエストが走ることはありません。
+
+---
+
+## まとめ
+
+この記事で学んだことは3つです。
+
+- goroutineを無制限に起動するとリソースが枯渇するリスクがある
+- Worker Poolパターンはworkerの数を固定することで並列数を制御する
+- GoWatchでは `jobs` / `results` channelを介してworkerに仕事を渡している
+
+**次回** はcontextを取り上げます。`ctx.Done()` が何者なのか、GoWatchのGraceful Shutdownでcontextがどう機能しているかを実装コードを交えて解説します。
+
+---
+
+## 参考
+
+- [Go by Example - Worker Pools](https://gobyexample.com/worker-pools)
+- [Go by Example - Channels](https://gobyexample.com/channels)
+- [pkg.go.dev/context](https://pkg.go.dev/context)

--- a/docs/qiita/03_context_cancel.md
+++ b/docs/qiita/03_context_cancel.md
@@ -1,0 +1,176 @@
+# GoWatchを作りながら学ぶGoの並行処理 #3 — contextでキャンセルを伝播させる
+
+## はじめに
+
+前回はWorker Poolパターンを学びました。
+
+- goroutineを無制限に起動するとリソースが枯渇するリスクがある
+- Worker Poolパターンはworkerの数を固定することで並列数を制御する
+- GoWatchでは `jobs` / `results` channelを介してworkerに仕事を渡している
+
+今回は `worker()` のコードに登場した `ctx.Done()` の正体を解説します。contextを理解することでGoWatchのGraceful Shutdownがどう機能しているかが見えてきます。
+
+---
+
+## contextとは
+
+contextはGoの標準パッケージで、**キャンセルやタイムアウトの信号を複数のgoroutineに伝播させる**仕組みです。
+
+Webアプリケーションでよくあるケースを考えてみます。
+
+- HTTPリクエストが来てDBクエリを実行中にクライアントが切断した
+- 外部APIへのリクエストが5秒以上かかっている
+
+こういったとき、処理を続けても意味がありません。contextを使うと「もう処理をやめてよい」という信号を関連するすべてのgoroutineに一斉に伝えられます。
+
+### ctx.Done() とは
+
+`ctx.Done()` はchannelを返します。contextがキャンセルされるとこのchannelが閉じられます。
+
+```go
+select {
+case <-ctx.Done():
+    // キャンセルされたので処理を終了する
+    return
+}
+```
+
+前回の `worker()` で `ctx.Done()` を監視していたのはこのためです。アプリケーション終了時にcontextがキャンセルされると、すべてのworkerがこのcaseに入って安全に終了します。
+
+---
+
+## WithCancel / WithTimeout の使い分け
+
+contextは親から子へ派生させて使います。代表的な2つを見ていきます。
+
+### context.WithCancel
+
+任意のタイミングでキャンセルできるcontextを作ります。
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+go func() {
+    // ctxを受け取って処理する
+    doSomething(ctx)
+}()
+
+// 何らかの条件でキャンセル
+cancel()
+```
+
+`cancel()` を呼ぶと派生したすべてのcontextに即座にキャンセルが伝播します。
+
+### context.WithTimeout
+
+指定した時間が経過すると自動でキャンセルされるcontextを作ります。
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+// 5秒以内に完了しなければctxがキャンセルされる
+result, err := http.Get("https://example.com")
+```
+
+外部へのHTTPリクエストやDBクエリなど「時間がかかりすぎたら止める」用途に使います。
+
+---
+
+## GoWatchでのcontext階層
+
+GoWatchでは3層のcontext階層を組んでいます。
+
+```
+[appCtx]  signal.NotifyContext — SIGTERMで自動キャンセル
+    │
+    └─ [cycleCtx]  WithCancel — 1チェックサイクル全体を管理
+            │
+            └─ [reqCtx]  WithTimeout(5s) — 1URLへのHTTPリクエストを管理
+```
+
+### appCtx — アプリケーション全体
+
+```go
+appCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+defer stop()
+```
+
+`signal.NotifyContext` はOSからの終了シグナル（SIGTERM / SIGINT）を受け取ると自動でキャンセルするcontextを作ります。`Ctrl+C` を押したときやDockerコンテナの停止時に発火します。
+
+### cycleCtx — 1チェックサイクル全体
+
+```go
+cycleCtx, cycleCancel := context.WithCancel(appCtx)
+defer cycleCancel()
+```
+
+1回のチェックサイクル（全URLへのリクエスト一巡）を管理します。`appCtx` から派生しているため、アプリケーションが終了するとこのcontextも連動してキャンセルされます。
+
+### reqCtx — 1URLへのリクエスト
+
+```go
+reqCtx, reqCancel := context.WithTimeout(cycleCtx, 5*time.Second)
+defer reqCancel()
+```
+
+個々のHTTPリクエストに5秒のタイムアウトを設定します。レスポンスが遅いURLがあっても他のチェックを止めません。
+
+---
+
+## Graceful Shutdown
+
+Graceful Shutdownとは、終了シグナルを受け取ったあと**処理中のリクエストを完了させてから安全に停止する**仕組みです。
+
+GoWatchでは以下の流れで実現しています。
+
+```
+① Ctrl+C / SIGTERM を受信
+        │
+        ▼
+② appCtx がキャンセルされる
+        │
+        ▼
+③ cycleCtx → reqCtx へキャンセルが伝播
+        │
+        ▼
+④ worker() の ctx.Done() が発火して全workerが終了
+        │
+        ▼
+⑤ HTTPサーバーが Shutdown(ctx) で既存リクエストの完了を待って停止
+```
+
+```go
+<-appCtx.Done() // SIGTERMを待つ
+
+shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer shutdownCancel()
+
+// 10秒以内に既存リクエストを処理し終えてから停止
+if err := srv.Shutdown(shutdownCtx); err != nil {
+    log.Printf("server shutdown error: %v", err)
+}
+```
+
+`appCtx` がキャンセルされた瞬間に処理を強制終了するのではなく、進行中の処理が終わるのを最大10秒待ってから停止します。
+
+---
+
+## まとめ
+
+この記事で学んだことは3つです。
+
+- contextはキャンセルやタイムアウトの信号を複数のgoroutineに伝播させる仕組み
+- `WithCancel` は任意のタイミングで、`WithTimeout` は時間経過で自動キャンセルする
+- GoWatchでは3層のcontext階層でアプリ全体・サイクル・個別リクエストのライフサイクルを管理している
+
+**次回** は実装を通じてハマったポイントをまとめます。`defer` のループ内での誤用、ポインタ型と値型の罠、goroutineリークを防ぐ考え方を解説します。
+
+---
+
+## 参考
+
+- [pkg.go.dev/context](https://pkg.go.dev/context)
+- [Go by Example - Context](https://gobyexample.com/context)
+- [DigitalOcean - How To Use Contexts in Go](https://www.digitalocean.com/community/tutorials/how-to-use-contexts-in-go)

--- a/docs/qiita/04_go_concurrency_gotchas.md
+++ b/docs/qiita/04_go_concurrency_gotchas.md
@@ -1,0 +1,212 @@
+# GoWatchを作りながら学ぶGoの並行処理 #4 — 実装してわかったハマりどころまとめ
+
+## はじめに
+
+前回はcontextを学びました。
+
+- contextはキャンセルやタイムアウトの信号を複数のgoroutineに伝播させる仕組み
+- `WithCancel` は任意のタイミングで、`WithTimeout` は時間経過で自動キャンセルする
+- GoWatchでは3層のcontext階層でアプリ全体・サイクル・個別リクエストのライフサイクルを管理している
+
+最終回の今回は、GoWatchを実装する中で実際にハマったポイントを3つ紹介します。どれも「動いているように見えるが実は問題がある」種類のバグで、Goに慣れていないと気づきにくいものです。
+
+---
+
+## ハマりどころ① deferをループ内で使ってはいけない
+
+### 問題のコード
+
+```go
+// ❌ 問題のある実装
+func (c *Checker) worker(ctx context.Context) {
+    for {
+        select {
+        case url := <-c.jobs:
+            resp, err := http.Get(url)
+            if err != nil {
+                continue
+            }
+            defer resp.Body.Close() // ← ここが問題
+        }
+    }
+}
+```
+
+一見問題なさそうですが、これは深刻なリソースリークを引き起こします。
+
+### なぜ問題なのか
+
+`defer` は**その関数が返るときに実行される**仕組みです。ループの中で `defer` を使うと、ループが回るたびに `defer` が積み重なり、関数が終了するまで一切実行されません。
+
+`worker()` は無限ループで動き続けるため、`resp.Body.Close()` は永遠に呼ばれません。その結果、HTTPレスポンスのBodyが開きっぱなしになり、コネクションを占有し続けます。
+
+### 正しい書き方
+
+```go
+// ✅ 正しい実装
+func (c *Checker) worker(ctx context.Context) {
+    for {
+        select {
+        case url := <-c.jobs:
+            resp, err := http.Get(url)
+            if err != nil {
+                continue
+            }
+            resp.Body.Close() // deferを使わず明示的に呼ぶ
+        }
+    }
+}
+```
+
+ループ内では `defer` を使わず、使い終わったタイミングで明示的に呼びます。もしくは処理を別関数に切り出して `defer` を使う方法もあります。
+
+```go
+// ✅ 別関数に切り出す方法
+func (c *Checker) check(ctx context.Context, url string) CheckResult {
+    resp, err := http.Get(url)
+    if err != nil {
+        return CheckResult{URL: url, IsDown: true}
+    }
+    defer resp.Body.Close() // 関数が終わると確実に呼ばれる
+    // ...
+}
+```
+
+---
+
+## ハマりどころ② ポインタ型と値型の罠（\*time.Ticker）
+
+### 問題のコード
+
+```go
+// ❌ 問題のある実装
+type Checker struct {
+    ticker time.Ticker // 値型で持っている
+}
+
+func (c *Checker) tickerLoop(ctx context.Context) {
+    c.ticker = *time.NewTicker(30 * time.Second)
+    defer c.ticker.Stop()
+    // ...
+}
+```
+
+### なぜ問題なのか
+
+`time.NewTicker()` はポインタ（`*time.Ticker`）を返します。これを値型（`time.Ticker`）にコピーすると、内部のchannelや状態が意図しない形でコピーされます。
+
+Goでは**内部にchannelやmutexを持つ型は値コピーしてはいけない**というルールがあります。コピーした瞬間に元のTickerと内部状態が乖離し、予期しない動作を引き起こします。
+
+### 正しい書き方
+
+```go
+// ✅ 正しい実装
+type Checker struct {
+    ticker *time.Ticker // ポインタ型で持つ
+}
+
+func (c *Checker) tickerLoop(ctx context.Context) {
+    c.ticker = time.NewTicker(30 * time.Second)
+    defer c.ticker.Stop()
+    // ...
+}
+```
+
+ポインタで持つことで、内部状態を共有したまま同じTickerを参照し続けられます。
+
+一般的な判断基準として、`New〇〇()` がポインタを返す型はポインタで持つと覚えておくと安全です。
+
+---
+
+## ハマりどころ③ goroutineリークを防ぐ考え方
+
+### goroutineリークとは
+
+goroutineリークとは、**不要になったgoroutineが終了せずにメモリを占有し続ける**状態です。
+
+よくある原因は「受信されることのないchannelを待ち続けるgoroutine」です。
+
+```go
+// ❌ リークするコード
+func leak() {
+    ch := make(chan int)
+    go func() {
+        val := <-ch // 誰も送信しないので永遠に待ち続ける
+        fmt.Println(val)
+    }()
+    // chに何も送らずに関数が終わる
+}
+```
+
+このgoroutineはプログラムが終了するまでメモリに残り続けます。
+
+### GoWatchでどう防いでいるか
+
+GoWatchでは2つの方針でgoroutineリークを防いでいます。
+
+**① すべてのgoroutineにctxを渡す**
+
+```go
+func (c *Checker) worker(ctx context.Context) {
+    for {
+        select {
+        case <-ctx.Done(): // アプリ終了時に必ずここに入る
+            return
+        case url := <-c.jobs:
+            // 処理
+        }
+    }
+}
+```
+
+`ctx.Done()` を監視することで、アプリケーション終了時にすべてのgoroutineが確実に終了します。
+
+**② channelのクローズを明示的に管理する**
+
+```go
+// tickerLoopが終了するときにjobsをクローズする
+func (c *Checker) tickerLoop(ctx context.Context) {
+    defer close(c.jobs)
+    // ...
+}
+```
+
+送信側がchannelをクローズすると、受信側の `for range ch` は自動的に終了します。これによりworkerが無限に待ち続ける状態を防げます。
+
+---
+
+## このシリーズを振り返って
+
+4回にわたってGoWatchの実装を通じてGoの並行処理を学びました。
+
+| 回  | テーマ              | 学んだこと                                      |
+| --- | ------------------- | ----------------------------------------------- |
+| #1  | goroutine / channel | 並行処理の基本単位とデータの渡し方              |
+| #2  | Worker Pool         | goroutineの数を制御して安全に並列処理する       |
+| #3  | context             | キャンセルとタイムアウトをgoroutineに伝播させる |
+| #4  | ハマりどころ        | defer・ポインタ・goroutineリークの落とし穴      |
+
+並行処理は「動いているように見えるが実は問題がある」バグが多い領域です。今回紹介した3つのハマりどころはどれも実際に踏んだものなので、同じところで詰まっている方の参考になれば嬉しいです。
+
+### 次に学ぶとよいこと
+
+このシリーズで扱えなかったテーマとして以下が挙げられます。
+
+- **sync.RWMutex** — 読み取りと書き込みを分けてロック効率を上げる
+- **goroutineリークのテスト** — `go.uber.org/goleak` を使った自動検出
+- **sync.WaitGroup** — 複数のgoroutineの完了を待つ別のアプローチ
+
+GoWatchのソースコードはこちら → GitHub（リンクは後ほど追記）
+
+最後まで読んでいただきありがとうございました。
+
+---
+
+## 参考
+
+- [Go by Example - Goroutines](https://gobyexample.com/goroutines)
+- [Go by Example - Channels](https://gobyexample.com/channels)
+- [Go by Example - Worker Pools](https://gobyexample.com/worker-pools)
+- [Go by Example - Context](https://gobyexample.com/context)
+- [pkg.go.dev/context](https://pkg.go.dev/context)
+- [DigitalOcean - How To Use Contexts in Go](https://www.digitalocean.com/community/tutorials/how-to-use-contexts-in-go)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -70,7 +70,7 @@ function reducer(state: State, action: Action): State {
 function App() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const [showModal, setShowModal] = useState(false);
-  const [toast, setToast] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<string[]>([]);
   const targets: Target[] = Array.from(state.targets.values());
 
   useEffect(() => {
@@ -91,15 +91,17 @@ function App() {
         // DOWN検知時にトースト表示
         if (msg.payload.status === 'down') {
           const target = targetsRef.current.get(msg.payload.target_id);
-          setToast(
-            `${target?.name ?? '不明'} (${target?.url ?? msg.payload.target_id}) がDOWNしました`
-          );
+          setToasts(prev => [...prev, `${target?.name ?? '不明'} (${target?.url ?? msg.payload.target_id}) がDOWNしました`]);
         }
         dispatch({ type: 'UPDATE_TARGET', payload: msg.payload });
         break;
       case 'cycle_complete':
         dispatch({ type: 'SET_LAST_CYCLE', payload: msg.payload });
         break;
+      case 'notification_error': {
+        setToasts(prev => [...prev, `エラー： ${msg.payload}`]);
+        break;
+      }
     }
   }, []);
 
@@ -121,7 +123,11 @@ function App() {
           selectedTargetId={state.selectedTargetId}
         />
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast(null)} />}
+      {toasts && toasts.map((message, index) => (
+        <div key={index}>
+          <Toast message={message} index={index} onClose={() => setToasts(prev => prev.filter((_, i) => i !== index))} />
+        </div>
+      ))}
       {state.selectedTargetId && (
         <ResponseChart
           targetId={state.selectedTargetId}

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -2,10 +2,11 @@ import { useEffect } from 'react';
 
 type Props = {
   message: string;
+  index: number;
   onClose: () => void;
 };
 
-export function Toast({ message, onClose }: Props) {
+export function Toast({ message, index, onClose }: Props) {
   useEffect(() => {
     const timer = setTimeout(onClose, 5000);
     return () => clearTimeout(timer);
@@ -15,7 +16,7 @@ export function Toast({ message, onClose }: Props) {
     <div
       style={{
         position: 'fixed',
-        top: '16px',
+        top: `${16 + index * 70}px`,
         right: '16px',
         background: '#ef4444',
         color: '#fff',

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -11,6 +11,7 @@ type Props = {
 
 export const useWebSocket = ({ onMessage, onConnect, onDisconnect }: Props) => {
   const wsRef = useRef<WebSocket | null>(null);
+  const isCleanedUp = useRef(false);
   const onMessageRef = useRef(onMessage);
 
   // onMessageが変わっても最新を参照する
@@ -38,8 +39,9 @@ export const useWebSocket = ({ onMessage, onConnect, onDisconnect }: Props) => {
     ws.onclose = () => {
       console.log('WebSocket disconnected, reconnecting...');
       onDisconnect();
-      // 3秒後に再接続
-      setTimeout(connect, 3000);
+      if (!isCleanedUp.current) {
+        setTimeout(connect, 3000);  // クリーンアップ済みなら再接続しない
+      }
     };
 
     ws.onerror = (e) => {
@@ -52,6 +54,7 @@ export const useWebSocket = ({ onMessage, onConnect, onDisconnect }: Props) => {
   useEffect(() => {
     connect();
     return () => {
+      isCleanedUp.current = true;
       wsRef.current?.close();
     };
   }, [connect]);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -24,7 +24,8 @@ export type WSMessage =
   | { type: 'check_result'; payload: CheckResult }
   | { type: 'cycle_start'; payload: CycleStart }
   | { type: 'cycle_complete'; payload: CycleComplete }
-  | { type: 'targets_updated'; payload: Target[] };
+  | { type: 'targets_updated'; payload: Target[] }
+  | { type: 'notification_error'; payload: string };
 
 export type CycleStart = {
   target_count: number;

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -77,6 +77,7 @@ func (c *Checker) worker(ctx context.Context) {
 			// targetを処理する
 			// 確認したいURLを検証する
 			start := time.Now()
+
 			cycleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			req, err := http.NewRequestWithContext(cycleCtx, http.MethodGet, target.URL, nil)
 			if err != nil {
@@ -91,6 +92,26 @@ func (c *Checker) worker(ctx context.Context) {
 					Error:     err.Error(),
 					CheckedAt: time.Now(),
 				}
+
+				// 通知処理
+				notifyMsg := fmt.Sprintf("DOWN: %s", target.URL)
+				notifyErr := c.notifier.Notify(notifyMsg)
+				if notifyErr != nil {
+					log.Printf("feild to send notify: %v", notifyErr)
+
+					// フロントエンドに情報を通知
+					msg := model.WSMessage{
+						Type:    "notification_error",
+						Payload: "エラー通知設定のURLを確認してください",
+					}
+					wsMsg, jsonErr := json.Marshal(msg)
+					if jsonErr != nil {
+						log.Printf("marshal notification_error: %v", jsonErr)
+					} else {
+						c.hub.Broadcast(wsMsg)
+					}
+				}
+
 				cancel()
 				continue
 			}
@@ -99,14 +120,6 @@ func (c *Checker) worker(ctx context.Context) {
 			elapsed := time.Since(start).Milliseconds()
 
 			status := c.judgeStatus(resp.StatusCode, elapsed)
-
-			if status == model.StatusDown {
-				message := fmt.Sprintf("DOWN: %s", target.URL)
-				err := c.notifier.Notify(message)
-				if err != nil {
-					log.Printf("feild to send notify: %v", err)
-				}
-			}
 
 			var result = model.CheckResult{
 				TargetID:       target.ID,
@@ -187,7 +200,6 @@ func (c *Checker) tickerLoop(ctx context.Context) {
 			cancel()
 
 			c.mu.Lock()
-			c.running = false
 			c.cycleStart = now
 			c.cycleExpected = len(targets)
 			c.cycleDone = 0
@@ -257,6 +269,10 @@ func (c *Checker) resultLoop(ctx context.Context) {
 
 			// 全件揃ったらcycle_completeを送る
 			if expected > 0 && done >= expected {
+				c.mu.Lock()
+				c.running = false
+				c.mu.Unlock()
+
 				cycleComplete := model.CycleComplete{
 					Total:       expected,
 					Up:          up,

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"gowatch/internal/model"
 	"gowatch/internal/store"
 	"gowatch/internal/websocket"
@@ -11,6 +12,10 @@ import (
 	"sync"
 	"time"
 )
+
+type Notifier interface {
+	Notify(message string) error
+}
 
 type Checker struct {
 	workNum       int
@@ -27,9 +32,10 @@ type Checker struct {
 	cycleSlow     int
 	cycleExpected int
 	cycleDone     int
+	notifier      Notifier
 }
 
-func New(workNum int, store *store.Store, hub *websocket.Hub) *Checker {
+func New(workNum int, store *store.Store, hub *websocket.Hub, notifier Notifier) *Checker {
 	// 1. jobの初期化
 	job := make(chan model.Target, workNum)
 
@@ -43,6 +49,7 @@ func New(workNum int, store *store.Store, hub *websocket.Hub) *Checker {
 		resultChannel: result,
 		store:         store,
 		hub:           hub,
+		notifier:      notifier,
 	}
 }
 
@@ -92,6 +99,14 @@ func (c *Checker) worker(ctx context.Context) {
 			elapsed := time.Since(start).Milliseconds()
 
 			status := c.judgeStatus(resp.StatusCode, elapsed)
+
+			if status == model.StatusDown {
+				message := fmt.Sprintf("DOWN: %s", target.URL)
+				err := c.notifier.Notify(message)
+				if err != nil {
+					log.Printf("feild to send notify: %v", err)
+				}
+			}
 
 			var result = model.CheckResult{
 				TargetID:       target.ID,

--- a/internal/notifier/nop.go
+++ b/internal/notifier/nop.go
@@ -1,0 +1,7 @@
+package notifier
+
+type NopNotifier struct{}
+
+func (nop *NopNotifier) Notify(message string) error {
+	return nil
+}

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -1,0 +1,39 @@
+package notifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type SlackNotifier struct {
+	webhookURL string
+}
+
+// 通知処理
+func (sl *SlackNotifier) Notify(message string) error {
+	// メッセージを作成
+	payload := map[string]string{"text": message}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to json encode: %w", err)
+	}
+
+	res, err := http.Post(sl.webhookURL, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to http post: %w", err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("failed to http post: %v", res.StatusCode)
+	}
+
+	return nil
+}
+
+func NewSlackNotifier(webhookURL string) *SlackNotifier {
+	return &SlackNotifier{webhookURL: webhookURL}
+}


### PR DESCRIPTION
## 関連 Issue

closes #19 

## 変更内容

- Slack通知機能の実装
- フロントエンドでの通知表示方法の修正

## 変更の種類

- [x] 新機能
- [x] バグ修正
- [x] リファクタリング
- [ ] ドキュメント

## 動作確認

- [x] ローカルでビルドが通る (`go build ./cmd/server`)
- [x] 受け入れ条件 (AC) をすべて満たしている
- [x] goroutine リークがないことを確認した（該当する場合）

## メモ

### 1. Notifier interface をどこに定義するか

**詰まり:** LaravelのようにInterface層（`internal/notifier/`）に定義しようとした。

**解決:** Goでは消費側が定義する慣習。`checker` がNotifierを必要としているため `internal/checker/checker.go` に定義する。`notifier` パッケージは `checker` を知らなくていい。メソッドの形が合えば自動的にinterfaceを満たす（implements宣言不要）。

**Laravelとの違い:**
- Laravel → 提供側がInterfaceを定義し、`implements` で明示的に紐付け
- Go → 消費側が定義し、形が合えば自動的に満たす

### 2. `*Notifier` vs `Notifier`

**詰まり:** 他のフィールド（`*store.Store`, `*websocket.Hub`）がポインタなので `*Notifier` にしようとした。

**解決:** interfaceは内部に既に実装へのポインタを持っている。`*Notifier` にすると二重ポインタになり、nilチェックや代入が複雑になるだけ。interfaceはそのまま `Notifier` として持つ。

```
*Store   → Store構造体のアドレスを持つ（1段階）
Notifier → 内部に既にアドレスを持つ（1段階）
*Notifier → interfaceのアドレスを持つ（2段階）← 不要
```

### 3. SLACK_WEBHOOK_URL 未設定時の対応

**詰まり:** `nil` を渡そうとしたがパニックの原因になる。

**解決:** `NopNotifier`（何もしない実装）を用意する。呼び出し側でnilチェックを書くより、`main.go` で一度だけ切り替える方が変更に強い。

```go
var n checker.Notifier
if webhookURL == "" {
    n = &notifier.NopNotifier{}
} else {
    n = notifier.NewSlackNotifier(webhookURL)
}
```

### 4. running フラグのタイミングが間違っていた

**詰まり:** `tickerLoop` でjob投入直後に `running = false` にしていたため、次のTickerが発火したとき前のサイクルが処理中なのに重複起動していた。

**解決:** `running = false` を `resultLoop` の `done >= expected`（全件完了）のタイミングに移動。

```
誤: job投入後すぐ → running = false
正: 全件の結果が返ってきたとき → running = false
```

### 5. WebSocketメッセージが2回届く

**詰まり:** `check_result` と `notification_error` がそれぞれ2回届いた。

**解決:** React 18のStrictModeが原因。開発環境では `useEffect` が「マウント → アンマウント → 再マウント」の順で2回実行される。`onclose` の中で再接続タイマーが動いてしまい、WebSocket接続が2つ作られていた。

`useRef` でクリーンアップフラグを管理して解決。

```typescript
const isCleanedUp = useRef(false);

ws.onclose = () => {
    if (!isCleanedUp.current) {
        setTimeout(connect, 3000);
    }
};

return () => {
    isCleanedUp.current = true;
    wsRef.current?.close();
};
```

**`let` ではダメな理由:** Reactはレンダリング（コンポーネント関数の再実行）のたびに `let` 変数を初期化する。`useRef` はReactが管理する外部メモリに保存するため初期化されない。GoのポインタとuseRefは「参照自体は固定して中身だけ変える」という概念が似ている。

## 設計の判断

**通知失敗はシステムを止めない**
GoWatchの目的は監視すること。Slack APIが落ちていてもURLの死活監視は継続できる。致命的でないエラーはログ + Toastに留め、処理を続ける。

**エラーの変数名を分ける**
同一スコープで複数のエラーを扱うときは変数名を明確に分ける（`err`, `notifyErr`, `jsonErr`）。上書きによるバグを防ぐ。

## Qiita・面接で語れるポイント

- Go の「消費側がinterfaceを定義する」という慣習とその理由（テスト容易性・依存の方向）
- LaravelのInterfaceとGoのInterfaceの根本的な違い（明示的 vs 暗黙的）
- NopNotifierパターン：nilチェックを呼び出し側に散らばらせない
- React StrictModeとuseRefによるWebSocket接続管理
